### PR TITLE
Document instructions for building HTML documentation from templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+ruby '1.8.7'
+gem 'webgen', '0.5.17'
+
+# Had to add hardcoded versions of all dependencies of webgen below, until all of their dependencies worked with 1.8
+# Then, committed Gemfile.lock
+gem 'addressable', '2.3.8'
+gem 'rake', '10.4.2'
+gem 'launchy', '2.4.3'
+gem 'rspec', '3.0'
+gem 'cmdparse', '2.0.2'
+gem 'maruku', '0.7.2' # Need a newer maruku version to render tables properly.
+# gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    cmdparse (2.0.2)
+    diff-lcs (1.2.5)
+    kramdown (1.10.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    maruku (0.7.2)
+    rake (10.4.2)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
+    webgen (0.5.17)
+      cmdparse (>= 2.0.2)
+      kramdown (>= 0.12.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  addressable (= 2.3.8)
+  cmdparse (= 2.0.2)
+  launchy (= 2.4.3)
+  maruku (= 0.7.2)
+  rake (= 10.4.2)
+  rspec (= 3.0)
+  webgen (= 0.5.17)
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 
 This repository contains content on [uniqush.org](http://uniqush.org). We use [webgen](http://webgen.rubyforge.org/) to generate the web site.
 
+Generating templates
+--------------------
+
+This requires version 0.5.9 of webgen, and ruby 1.8 (because of a dependency on rcov). To generate these templates locally, use rvm to temporarily use ruby 1.8:
+
+```bash
+rvm use 1.8.7
+bundle install
+webgen
+# Alternately, run the command `bundle exec rake auto_webgen` to regenerate the site in the background as changes are made.
+```


### PR DESCRIPTION
This adds instructions for installing webgen 0.5.9 under ruby 1.8.
    
I'm not familiar enough with webgen to migrate the templates and
extensions to webgen 1.5.
Some features have been removed, such as `used_nodes` in menus.
(I didn't see any example code for replacing that feature.)
Also, various modules of webgen were renamed/modified.
