### PR TITLE
Remove references to C2DM in current documentation

### DIFF
--- a/src/documentation/usage.page
+++ b/src/documentation/usage.page
@@ -18,19 +18,18 @@ Before executing any command below, make sure you have already started *uniqush-
 - [GCM] for Android
 - [APNS] for iOS
 - [ADM] for Kindle tablets
-- [C2DM] for Android (Deprecated by google. Should use GCM instead)
 
 
 ******
 
-## Get the Version of `uniqush-push` 
+## Get the Version of `uniqush-push`
 
 - URL: `/version`
 - Alternatively, you can run **`uniqush-push -version`** to get the version of `uniqush-push`
 
 ******
 
-## Stop `uniqush-push` 
+## Stop `uniqush-push`
 
 - URL: `/stop`
 
@@ -44,11 +43,11 @@ Before executing any command below, make sure you have already started *uniqush-
 
 ### Parameters for GCM Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For GCM Push Service Provider, this is always *gcm*  | 
- |  projectid  |  Project ID.  | 
- |  apikey  |  API Key  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For GCM Push Service Provider, this is always *gcm*  |
+ |  projectid  |  Project ID.  |
+ |  apikey  |  API Key  |
 
 Read [this](http://developer.android.com/guide/google/gcm/gs.html) article on
 how to get Project ID and API key. Note: you need to make a **Server key** not
@@ -56,24 +55,14 @@ an Android key.
 
 Example: `curl http://127.0.0.1:9898/addpsp -d service=myservice -d pushservicetype=gcm -d projectid=123 -d apikey=somekey`
 
-### Parameters for C2DM Push Service Provider (Deprecated) 
+### Parameters for APNS Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For C2DM Push Service Provider, this is always *c2dm*  | 
- |  senderid  |  Sender ID. An email account associated with the application's developer  | 
- |  authtoken  |  Sender Auth Token  | 
-
-Example: `curl http://127.0.0.1:9898/addpsp -d service=myservice -d pushservicetype=c2dm -d senderid=uniqush.go@gmail.com -d authtoken=faketoken`
-
-### Parameters for APNS Push Service Provider 
-
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For APNS Push Service Provider, this is always *apns*  | 
- |  cert  |  The absolute path to the certificate file in .pem format  | 
- |  key  |  The absolute path to the private key file in .pem format  | 
- |  sandbox  |  Optional. *true* for sandbox; otherwise for production environment  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For APNS Push Service Provider, this is always *apns*  |
+ |  cert  |  The absolute path to the certificate file in .pem format  |
+ |  key  |  The absolute path to the private key file in .pem format  |
+ |  sandbox  |  Optional. *true* for sandbox; otherwise for production environment  |
 
 Example: `curl http://127.0.0.1:9898/addpsp -d service=myservice -d pushservicetype=apns -d cert=/path/to/certificate.pem -d key=/path/to/privatekey.pem -d sandbox=true`
 
@@ -81,9 +70,9 @@ See [this blog](http://blog.boxedice.com/2010/06/05/how-to-renew-your-apple-push
 
 ### Parameters for ADM Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For ADM Push Service Provider, this is always *adm*  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For ADM Push Service Provider, this is always *adm*  |
  |  clientid  | The Client ID. |
  |  clientsecret | The Client Secret. |
 
@@ -104,45 +93,36 @@ Example: `curl http://127.0.0.1:9898/addpsp -d service=myservice -d clientid=som
 
 ******
 
-## Removing Push Service Provider 
+## Removing Push Service Provider
 
 - URL: `/rmpsp`
 
-### Parameters for GCM Push Service Provider 
+### Parameters for GCM Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For GCM Push Service Provider, this is always *gcm*  | 
- |  projectid  |  Project ID.  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For GCM Push Service Provider, this is always *gcm*  |
+ |  projectid  |  Project ID.  |
 
 Read [this](http://developer.android.com/guide/google/gcm/gs.html) article on how to get Project ID and API key.
 
 Example: `curl http://127.0.0.1:9898/rmpsp -d service=myservice -d pushservicetype=gcm -d projectid=123`
 
-### Parameters for C2DM Push Service Provider (Deprecated)  
+### Parameters for APNS Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For C2DM Push Service Provider, this is always *c2dm*  | 
- |  senderid  |  Sender ID. An email account associated with the application's developer  | 
-
-Example: `curl http://127.0.0.1:9898/rmpsp -d service=myservice -d pushservicetype=c2dm -d senderid=uniqush.go@gmail.com`
-
-### Parameters for APNS Push Service Provider 
-
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For APNS Push Service Provider, this is always *apns*  | 
- |  cert  |  The absolute path to the certificate file in .pem format  | 
- |  key  |  The absolute path to the private key file in .pem format  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For APNS Push Service Provider, this is always *apns*  |
+ |  cert  |  The absolute path to the certificate file in .pem format  |
+ |  key  |  The absolute path to the private key file in .pem format  |
 
 Example: `curl http://127.0.0.1:9898/rmpsp -d service=myservice -d pushservicetype=apns -d cert=/path/to/certificate.pem -d key=/path/to/privatekey.pem`
 
 ### Parameters for ADM Push Service Provider
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  pushservicetype  |  For ADM Push Service Provider, this is always *adm*  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  pushservicetype  |  For ADM Push Service Provider, this is always *adm*  |
  |  clientid  | The Client ID. |
  |  clientsecret | The Client Secret. |
 
@@ -164,122 +144,100 @@ Example: `curl http://127.0.0.1:9898/addpsp -d service=myservice -d clientid=som
 
 ******
 
-## Subscribe 
+## Subscribe
 
 - URL: `/subscribe`
 
-### Parameters for Android Devices Using GCM  
+### Parameters for Android Devices Using GCM
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Android Device using GCM, this is always *gcm*  |  
- |  regid  |  Registration ID  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For Android Device using GCM, this is always *gcm*  |
+ |  regid  |  Registration ID  |
 
 Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=gcm -d regid=fakeregid`
 
-### Parameters for Android Devices Using C2DM (Deprecated) 
+### Parameters for iOS Devices Using APNS
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Android Device using C2DM, this is always *c2dm*  |  
- |  account  |  The google account of the subscriber. NOTE: this MUST NOT be same as senderid. This is a bug/feature of C2DM  | 
- |  regid  |  Registration ID  | 
-
-Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=c2dm -d account=uniqush.client@gmail.com -d regid=fakeregid`
-
-### Parameters for iOS Devices Using APNS 
-
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For iOS device using APNS, this is always *apns*  | 
- |  devtoken  |  Device token  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For iOS device using APNS, this is always *apns*  |
+ |  devtoken  |  Device token  |
 
 Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=apns -d devtoken=some-device-token`
 
 ### Parameters for Kindle Devices Using ADM
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Kindle Device using ADM, this is always *adm*  |  
- |  regid  |  Registration ID  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For Kindle Device using ADM, this is always *adm*  |
+ |  regid  |  Registration ID  |
 
 Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d pushservicetype=adm -d subscriber=firehd -d regid=RegistrationId`
 
 ******
 
-## Unsubscribe 
+## Unsubscribe
 
 - URL: `/unsubscribe`
 
-### Parameters for Android Devices Using GCM  
+### Parameters for Android Devices Using GCM
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Android Device using GCM, this is always *gcm*  |  
- |  regid  |  Registration ID. NOTE: This registration ID must be exactly the same one used to subscribe. | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For Android Device using GCM, this is always *gcm*  |
+ |  regid  |  Registration ID. NOTE: This registration ID must be exactly the same one used to subscribe. |
 
 Example: `curl http://127.0.0.1:9898/unsubscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=gcm -d regid=fakeregid`
 
 The registration ID should be same one used to subscribe the service. That is: you don't need to consider if the GCM will update the registration ID for the device. Uniqush can handle it.
 
-### Parameters for Android Devices using C2DM (Deprecated)  
+### Parameters for iOS Devices Using APNS
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Android Device using C2DM, this is always *c2dm*  |  
- |  account  |  The google account of the subscriber  | 
- |  regid  |  Registration ID  | 
-
-Example: `curl http://127.0.0.1:9898/unsubscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=c2dm -d account=uniqush.client@gmail.com -d regid=fakeregid`
-
-### Parameters for iOS Devices Using APNS 
-
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For iOS device using APNS, this is always *apns*  | 
- |  devtoken  |  Device token  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For iOS device using APNS, this is always *apns*  |
+ |  devtoken  |  Device token  |
 
 Example: `curl http://127.0.0.1:9898/unsubscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=apns -d devtoken=devtoken`
 
 ### Parameters for Kindle Devices Using ADM
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name  | 
- |  subscriber  |  Subscriber Name  | 
- |  pushservicetype  |  For Kindle Device using ADM, this is always *adm*  |  
- |  regid  |  Registration ID  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name  |
+ |  subscriber  |  Subscriber Name  |
+ |  pushservicetype  |  For Kindle Device using ADM, this is always *adm*  |
+ |  regid  |  Registration ID  |
 
 Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d pushservicetype=adm -d subscriber=firehd -d regid=RegistrationId`
 
 
 ******
 
-## Push Message 
+## Push Message
 
 - URL: `/push`
 
-### Parameters 
+### Parameters
 
- |  **Parameter**  |  **Description**  | 
- |  service  |  Service Name. | 
- |  subscriber  |  Subscriber Name. Could be more than one subscriber. Comma separated. Asterisk (\*) could be used as a wildcard to match any string | 
- |  msg  |  Optional. Message Body  | 
+ |  **Parameter**  |  **Description**  |
+ |  service  |  Service Name. |
+ |  subscriber  |  Subscriber Name. Could be more than one subscriber. Comma separated. Asterisk (\*) could be used as a wildcard to match any string |
+ |  msg  |  Optional. Message Body  |
  | ttl | Optional. Time to live. How long (in seconds) the message should be kept on push service provider's server if the device is offline |
- |  badge  |  Optional. Badge  | 
- |  img  |  Optional. Image  | 
- |  sound  |  Optional. Sound  | 
+ |  badge  |  Optional. Badge  |
+ |  img  |  Optional. Image  |
+ |  sound  |  Optional. Sound  |
  | loc-key | Optional. loc-key for APNS |
  | loc-args | Optional. loc-args for APNS. It is a comma-separated string. |
  | action-loc-key | Option. action-loc-key for APNS. |
- |  *Reserved Parameter*  |  Any parameter whose name starts from "uniqush." is reserved by uniqush. Users should avoid using those parameter names. | 
- |  *User Defined Parameter*  |  Optional. Any other parameter is accepted which will be sent to mobile devices  | 
+ |  *Reserved Parameter*  |  Any parameter whose name starts from "uniqush." is reserved by uniqush. Users should avoid using those parameter names. |
+ |  *User Defined Parameter*  |  Optional. Any other parameter is accepted which will be sent to mobile devices  |
 
 At least one of the optional parameter should be provided, or it will be an empty message and won't be sent.
 
@@ -337,14 +295,13 @@ Example: `curl http://127.0.0.1:9898/nrdp -d service=myservice -d subscriber=uni
 
 ******
 
-## Related Topics 
+## Related Topics
 
-- [Basic Concepts](basic-concept.html): This document explains the basic concepts inside Uniqush. They are critical to using Uniqush. 
-- [Basic Operations](basic-opts.html): This document covers the basic operations provided by Uniqush. 
+- [Basic Concepts](basic-concept.html): This document explains the basic concepts inside Uniqush. They are critical to using Uniqush.
+- [Basic Operations](basic-opts.html): This document covers the basic operations provided by Uniqush.
 - [Install](install.html): This document explains how to install Uniqush and its dependencies.
-- [Configuration](config.html): This document explains the detail of configuration of Uniqush. 
+- [Configuration](config.html): This document explains the detail of configuration of Uniqush.
 
 [GCM]: http://developer.android.com/guide/google/gcm/index.html
 [APNS]: http://developer.apple.com/library/mac/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html
-[C2DM]: http://code.google.com/android/c2dm/
 [ADM]: https://developer.amazon.com/sdk/adm.html

--- a/src/index.page
+++ b/src/index.page
@@ -18,7 +18,7 @@ basic idea of uniqush.
 
 The latest news about Uniqush will be posted to our
 [blog](http://blog.uniqush.org). Or you can follow us on twitter:
-[@uniqush](http://twitter.com/uniqush). 
+[@uniqush](http://twitter.com/uniqush).
 
 The latest release version is [1.5.2](release-notes/rn-uniqush-push-1-5-2.html).
 
@@ -30,7 +30,7 @@ The latest release version is [1.5.2](release-notes/rn-uniqush-push-1-5-2.html).
   android, iOS, etc. And we will support more in the future.
 - Simple and unified interface for Apps' server developers. You don't need to
   care about receiver's system, simply send an HTTP request to uniqush server
-  and it will do all things for you. 
+  and it will do all things for you.
 - No need to implement re-send on failure mechanisms, uniqush will re-send the
   notification on a recoverable error whenever possible.
 - Wildcard multicast, so that you can group your users and multicast notifications
@@ -44,7 +44,6 @@ The latest release version is [1.5.2](release-notes/rn-uniqush-push-1-5-2.html).
 - [GCM] for Android
 - [APNS] for iOS
 - [ADM] for Kindle tablets
-- [C2DM] for Android (Deprecated by google. Should use GCM instead)
 
 ## Source Code & Download
 
@@ -59,13 +58,12 @@ You can either send a mail to [uniqush.go at gmail dot com] privately, or post y
 ## License
 
 - The source code of uniqush is distributed under [Apache License 2.0].
-- Documents on this website are under a [Creative Commons Attribution 3.0 Unported License]. 
+- Documents on this website are under a [Creative Commons Attribution 3.0 Unported License].
 
 [uniqush.go at gmail dot com]: mailto:uniqush.go@gmail.com
 [mailing list]: http://groups.google.com/group/uniqush
 [GCM]: http://developer.android.com/guide/google/gcm/index.html
 [APNS]: http://developer.apple.com/library/mac/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html
-[C2DM]: http://code.google.com/android/c2dm/
 [ADM]: https://developer.amazon.com/sdk/adm.html
 [our github repositories]: http://github.com/uniqush
 [install]: documentation/install.html


### PR DESCRIPTION
It was shut down completely on October 20th, 2015
and deprecated in June 2012.

Version 2.0.0 of uniqush-push removed support for C2DM