### PR TITLE
Update documentation: document new APIs, add release notes

### DIFF
--- a/src/documentation/usage.page
+++ b/src/documentation/usage.page
@@ -216,6 +216,38 @@ Example: `curl http://127.0.0.1:9898/unsubscribe -d service=myservice -d subscri
 
 Example: `curl http://127.0.0.1:9898/subscribe -d service=myservice -d pushservicetype=adm -d subscriber=firehd -d regid=RegistrationId`
 
+## Get Subscriptions
+
+- URL: `/subscriptions`
+
+### Parameters for getting subscriptions for a set of service names
+
+ |  **Parameter**  |  **Description**  |
+ |  services  |  Service Name(s)  |
+ |  subscriber  |  Subscriber Name  |
+
+Example: `curl http://127.0.0.1:9898/subscriptions -d services=myservice,myotherservice -d subscriber=uniqush.client`
+
+### Parameters for getting subscriptions across each service
+
+ |  **Parameter**  |  **Description**  |
+ |  subscriber  |  Subscriber Name  |
+
+Example: `curl http://127.0.0.1:9898/subscriptions -d subscriber=uniqush.client`
+
+If this fails to return results for some valid services, then use the `/rebuildserviceset` API.
+
+## Get PSPs
+
+- URL: `/psps`
+
+Returns JSON representing the PSPs stored in Uniqush, along with their configs (API keys, paths to certificates, service type, etc.).
+
+## Migrating from 1.0 to 2.0
+
+- URL: `/rebuildserviceset`
+
+Initializes the set of all service names.  This API is needed for the /subscriptions and the /psps APIs to work(and be efficient).
 
 ******
 

--- a/src/downloads.page
+++ b/src/downloads.page
@@ -12,7 +12,19 @@ Please follow the instruction from [Install Uniqush](documentation/install.html)
 
 ##uniqush-push
 
-latest version: **1.5.2**
+latest version: **2.1.0**
+
+[uniqush-push 2.1.0 release note](release-notes/rn-uniqush-push-2-1-0.html)
+
+- [amd64 2.1.0 deb](downloads/uniqush-push_2.1.0_amd64.deb)
+- [amd64 2.1.0 rpm](downloads/uniqush-push-2.1.0-1.x86_64.rpm)
+- [amd64 2.1.0 tar.gz](downloads/uniqush-push_2.1.0_x86_64.tar.gz)
+
+[uniqush-push 2.0.0 release note](release-notes/rn-uniqush-push-2-0-0.html)
+
+- [amd64 2.0.0 deb](downloads/uniqush-push_2.0.0_amd64.deb)
+- [amd64 2.0.0 rpm](downloads/uniqush-push-2.0.0-1.x86_64.rpm)
+- [amd64 2.0.0 tar.gz](downloads/uniqush-push_2.0.0_x86_64.tar.gz)
 
 [uniqush-push 1.5.2 release note](release-notes/rn-uniqush-push-1-5-2.html)
 

--- a/src/index.page
+++ b/src/index.page
@@ -20,7 +20,7 @@ The latest news about Uniqush will be posted to our
 [blog](http://blog.uniqush.org). Or you can follow us on twitter:
 [@uniqush](http://twitter.com/uniqush).
 
-The latest release version is [1.5.2](release-notes/rn-uniqush-push-1-5-2.html).
+The latest release version is [2.1.0](release-notes/rn-uniqush-push-2-1-0.html).
 
 ## Features
 

--- a/src/release-notes/rn-uniqush-push-2-0-0.page
+++ b/src/release-notes/rn-uniqush-push-2-0-0.page
@@ -1,0 +1,32 @@
+---
+title: Release Note 2.0.0
+in_menu: false
+author: Nan Deng
+author_url: http://monnand.me
+---
+
+# Release Note 2.0.0
+
+15-Mar-2016
+
+This release contains a change to the response format, as well as bug fixes and improvements.
+
+Download:
+
+- [amd64 2.0.0 deb](http://uniqush.org/downloads/uniqush-push_2.0.0_amd64.deb)
+- [amd64 2.0.0 rpm](http://uniqush.org/downloads/uniqush-push-2.0.0-1.x86_64.rpm)
+- [amd64 2.0.0 tar.gz](http://uniqush.org/downloads/uniqush-push_2.0.0_x86_64.tar.gz)
+
+ChangeLog:
+
+- *improvement* Changed the response format of most APIs from logs to JSON.
+  This allows clients to reliably parse results and errors from the API response.
+  **This will break clients that parse the old format**
+- *improvement* Allow 2048 byte APNS payloads
+- *bugfix* Fix various memory leaks.
+- *bugfix* Fix bugs in closing connections.
+- Remove support for C2DM, which was shut down by Google on October 2015.
+
+[issue 68]: https://github.com/uniqush/uniqush-push/issues/68
+[issue 70]: https://github.com/uniqush/uniqush-push/issues/70
+[issue 76]: https://github.com/uniqush/uniqush-push/issues/76

--- a/src/release-notes/rn-uniqush-push-2-1-0.page
+++ b/src/release-notes/rn-uniqush-push-2-1-0.page
@@ -1,0 +1,27 @@
+---
+title: Release Note 2.1.0
+in_menu: false
+author: Nan Deng
+author_url: http://monnand.me
+---
+
+# Release Note 2.1.0
+
+01-Mar-2016
+
+This release contains bugfixes, new APIs and improvements.
+
+Download:
+
+- [amd64 2.1.0 deb](http://uniqush.org/downloads/uniqush-push_2.1.0_amd64.deb)
+- [amd64 2.1.0 rpm](http://uniqush.org/downloads/uniqush-push-2.1.0-1.x86_64.rpm)
+- [amd64 2.1.0 tar.gz](http://uniqush.org/downloads/uniqush-push_2.1.0_x86_64.tar.gz)
+
+ChangeLog:
+
+- *improvement* Add new APIs for listing the subscriptions of a subscriber and for listing the services exist.
+- *bugfix* Fix concurrency issues in ADM, APNS.  Change the APNS implementation from a buggy connection pool to a reliable worker pool.
+- *bugfix* Fix a bug which would lead to an infinite loop in rare circumstances.
+- *improvement* Remove Go's default HTML escaping of JSON payloads, for APNS.  The APNS servers now render payloads with characters such as '"' properly.
+- *improvement* Add more details to error messages.
+- *improvement* Add enough buffer space for potential 100-byte APNS device tokens.


### PR DESCRIPTION
- Add release notes, need to add issue numbers
- Update latest version on the index page and downloads page
- Commit expected contents of downloads.page (The new packages should be built before the website documentation is built). This assumes [0d8cf506cb3b6d0756325c939d0bb7c2af2fd1cd](0d8cf506cb3b6d0756325c939d0bb7c2af2fd1cd) for 2.1.0 release, [e17e0012be757b1e18f1f79f936db1a8fe1a7a6f](https://github.com/uniqush/uniqush-push/commits/e17e0012be757b1e18f1f79f936db1a8fe1a7a6f) for 2.0.0 release
- Document new APIs

(One can ?w=1 to the URL to ignore the removal of trailing whitespace: https://github.com/uniqush/uniqush-www/pull/8/files?w=1 )
