### PR TITLE
Link to GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains content on [uniqush.org](http://uniqush.org). We use [w
 Generating templates
 --------------------
 
+**A dockerized version is available at `./main.sh`, to avoid the need to fiddle with specifics of the host operating system.** Using that script is strongly recommended.
+
 This requires version 0.5.9 of webgen, and ruby 1.8 (because of a dependency on rcov). To generate these templates locally, use rvm to temporarily use ruby 1.8:
 
 ```bash
@@ -12,5 +14,3 @@ bundle install
 webgen
 # Alternately, run the command `bundle exec rake auto_webgen` to regenerate the site in the background as changes are made.
 ```
-
-A dockerized version is available at `./main.sh`, to avoid the need to fiddle with specifics of the host operating system.

--- a/ext/init.rb
+++ b/ext/init.rb
@@ -125,7 +125,7 @@ programs.uniq.each do | prog |
             package_types.each do | pkg |
                 arch_name = archconv[pkg][arch]
                 filename = prog + prog_ver_sep[pkg] + ver + ver_arch_sep[pkg] + arch_name + "." + pkg
-                downloadf.write("- [" + arch + " " + ver + " " + pkg + "](downloads/" + filename + ")\n")
+                downloadf.write("- [" + arch + " " + ver + " " + pkg + "](https://github.com/uniqush/uniqush-push/releases/tag/" + ver + ")\n")
             end
         end
     end

--- a/src/downloads.page
+++ b/src/downloads.page
@@ -16,108 +16,108 @@ latest version: **2.5.0**
 
 [uniqush-push 2.5.0 release note](release-notes/rn-uniqush-push-2-5-0.html)
 
-- [amd64 2.5.0 deb](downloads/uniqush-push_2.5.0_amd64.deb)
-- [amd64 2.5.0 rpm](downloads/uniqush-push-2.5.0-1.x86_64.rpm)
-- [amd64 2.5.0 tar.gz](downloads/uniqush-push_2.5.0_x86_64.tar.gz)
+- [amd64 2.5.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.5.0)
+- [amd64 2.5.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.5.0)
+- [amd64 2.5.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.5.0)
 
 [uniqush-push 2.4.0 release note](release-notes/rn-uniqush-push-2-4-0.html)
 
-- [amd64 2.4.0 deb](downloads/uniqush-push_2.4.0_amd64.deb)
-- [amd64 2.4.0 rpm](downloads/uniqush-push-2.4.0-1.x86_64.rpm)
-- [amd64 2.4.0 tar.gz](downloads/uniqush-push_2.4.0_x86_64.tar.gz)
+- [amd64 2.4.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.4.0)
+- [amd64 2.4.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.4.0)
+- [amd64 2.4.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.4.0)
 
 [uniqush-push 2.3.0 release note](release-notes/rn-uniqush-push-2-3-0.html)
 
-- [amd64 2.3.0 deb](downloads/uniqush-push_2.3.0_amd64.deb)
-- [amd64 2.3.0 rpm](downloads/uniqush-push-2.3.0-1.x86_64.rpm)
-- [amd64 2.3.0 tar.gz](downloads/uniqush-push_2.3.0_x86_64.tar.gz)
+- [amd64 2.3.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.3.0)
+- [amd64 2.3.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.3.0)
+- [amd64 2.3.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.3.0)
 
 [uniqush-push 2.2.0 release note](release-notes/rn-uniqush-push-2-2-0.html)
 
-- [amd64 2.2.0 deb](downloads/uniqush-push_2.2.0_amd64.deb)
-- [amd64 2.2.0 rpm](downloads/uniqush-push-2.2.0-1.x86_64.rpm)
-- [amd64 2.2.0 tar.gz](downloads/uniqush-push_2.2.0_x86_64.tar.gz)
+- [amd64 2.2.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.2.0)
+- [amd64 2.2.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.2.0)
+- [amd64 2.2.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.2.0)
 
 [uniqush-push 2.1.0 release note](release-notes/rn-uniqush-push-2-1-0.html)
 
-- [amd64 2.1.0 deb](downloads/uniqush-push_2.1.0_amd64.deb)
-- [amd64 2.1.0 rpm](downloads/uniqush-push-2.1.0-1.x86_64.rpm)
-- [amd64 2.1.0 tar.gz](downloads/uniqush-push_2.1.0_x86_64.tar.gz)
+- [amd64 2.1.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.1.0)
+- [amd64 2.1.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.1.0)
+- [amd64 2.1.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.1.0)
 
 [uniqush-push 2.0.0 release note](release-notes/rn-uniqush-push-2-0-0.html)
 
-- [amd64 2.0.0 deb](downloads/uniqush-push_2.0.0_amd64.deb)
-- [amd64 2.0.0 rpm](downloads/uniqush-push-2.0.0-1.x86_64.rpm)
-- [amd64 2.0.0 tar.gz](downloads/uniqush-push_2.0.0_x86_64.tar.gz)
+- [amd64 2.0.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/2.0.0)
+- [amd64 2.0.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/2.0.0)
+- [amd64 2.0.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/2.0.0)
 
 [uniqush-push 1.5.2 release note](release-notes/rn-uniqush-push-1-5-2.html)
 
-- [amd64 1.5.2 deb](downloads/uniqush-push_1.5.2_amd64.deb)
-- [amd64 1.5.2 rpm](downloads/uniqush-push-1.5.2-1.x86_64.rpm)
-- [amd64 1.5.2 tar.gz](downloads/uniqush-push_1.5.2_x86_64.tar.gz)
+- [amd64 1.5.2 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.5.2)
+- [amd64 1.5.2 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.5.2)
+- [amd64 1.5.2 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.5.2)
 
 [uniqush-push 1.5.1 release note](release-notes/rn-uniqush-push-1-5-1.html)
 
-- [amd64 1.5.1 deb](downloads/uniqush-push_1.5.1_amd64.deb)
-- [amd64 1.5.1 rpm](downloads/uniqush-push-1.5.1-1.x86_64.rpm)
-- [amd64 1.5.1 tar.gz](downloads/uniqush-push_1.5.1_x86_64.tar.gz)
+- [amd64 1.5.1 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.5.1)
+- [amd64 1.5.1 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.5.1)
+- [amd64 1.5.1 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.5.1)
 
 [uniqush-push 1.5.0 release note](release-notes/rn-uniqush-push-1-5-0.html)
 
-- [amd64 1.5.0 deb](downloads/uniqush-push_1.5.0_amd64.deb)
-- [amd64 1.5.0 rpm](downloads/uniqush-push-1.5.0-1.x86_64.rpm)
-- [amd64 1.5.0 tar.gz](downloads/uniqush-push_1.5.0_x86_64.tar.gz)
+- [amd64 1.5.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.5.0)
+- [amd64 1.5.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.5.0)
+- [amd64 1.5.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.5.0)
 
 [uniqush-push 1.4.5 release note](release-notes/rn-uniqush-push-1-4-5.html)
 
-- [amd64 1.4.5 deb](downloads/uniqush-push_1.4.5_amd64.deb)
-- [amd64 1.4.5 rpm](downloads/uniqush-push-1.4.5-1.x86_64.rpm)
-- [amd64 1.4.5 tar.gz](downloads/uniqush-push_1.4.5_x86_64.tar.gz)
+- [amd64 1.4.5 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.5)
+- [amd64 1.4.5 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.5)
+- [amd64 1.4.5 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.5)
 
 [uniqush-push 1.4.4 release note](release-notes/rn-uniqush-push-1-4-4.html)
 
-- [amd64 1.4.4 deb](downloads/uniqush-push_1.4.4_amd64.deb)
-- [amd64 1.4.4 rpm](downloads/uniqush-push-1.4.4-1.x86_64.rpm)
-- [amd64 1.4.4 tar.gz](downloads/uniqush-push_1.4.4_x86_64.tar.gz)
+- [amd64 1.4.4 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.4)
+- [amd64 1.4.4 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.4)
+- [amd64 1.4.4 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.4)
 
 [uniqush-push 1.4.3 release note](release-notes/rn-uniqush-push-1-4-3.html)
 
-- [amd64 1.4.3 deb](downloads/uniqush-push_1.4.3_amd64.deb)
-- [amd64 1.4.3 rpm](downloads/uniqush-push-1.4.3-1.x86_64.rpm)
-- [amd64 1.4.3 tar.gz](downloads/uniqush-push_1.4.3_x86_64.tar.gz)
+- [amd64 1.4.3 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.3)
+- [amd64 1.4.3 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.3)
+- [amd64 1.4.3 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.3)
 
 [uniqush-push 1.4.2 release note](release-notes/rn-uniqush-push-1-4-2.html)
 
-- [amd64 1.4.2 deb](downloads/uniqush-push_1.4.2_amd64.deb)
-- [amd64 1.4.2 rpm](downloads/uniqush-push-1.4.2-1.x86_64.rpm)
-- [amd64 1.4.2 tar.gz](downloads/uniqush-push_1.4.2_x86_64.tar.gz)
+- [amd64 1.4.2 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.2)
+- [amd64 1.4.2 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.2)
+- [amd64 1.4.2 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.2)
 
 [uniqush-push 1.4.1 release note](release-notes/rn-uniqush-push-1-4-1.html)
 
-- [amd64 1.4.1 deb](downloads/uniqush-push_1.4.1_amd64.deb)
-- [amd64 1.4.1 rpm](downloads/uniqush-push-1.4.1-1.x86_64.rpm)
-- [amd64 1.4.1 tar.gz](downloads/uniqush-push_1.4.1_x86_64.tar.gz)
+- [amd64 1.4.1 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.1)
+- [amd64 1.4.1 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.1)
+- [amd64 1.4.1 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.1)
 
 [uniqush-push 1.4.0 release note](release-notes/rn-uniqush-push-1-4-0.html)
 
-- [amd64 1.4.0 deb](downloads/uniqush-push_1.4.0_amd64.deb)
-- [amd64 1.4.0 rpm](downloads/uniqush-push-1.4.0-1.x86_64.rpm)
-- [amd64 1.4.0 tar.gz](downloads/uniqush-push_1.4.0_x86_64.tar.gz)
+- [amd64 1.4.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.4.0)
+- [amd64 1.4.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.4.0)
+- [amd64 1.4.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.4.0)
 
 [uniqush-push 1.3.2 release note](release-notes/rn-uniqush-push-1-3-2.html)
 
-- [amd64 1.3.2 deb](downloads/uniqush-push_1.3.2_amd64.deb)
-- [amd64 1.3.2 rpm](downloads/uniqush-push-1.3.2-1.x86_64.rpm)
-- [amd64 1.3.2 tar.gz](downloads/uniqush-push_1.3.2_x86_64.tar.gz)
+- [amd64 1.3.2 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.3.2)
+- [amd64 1.3.2 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.3.2)
+- [amd64 1.3.2 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.3.2)
 
 [uniqush-push 1.3.1 release note](release-notes/rn-uniqush-push-1-3-1.html)
 
-- [amd64 1.3.1 deb](downloads/uniqush-push_1.3.1_amd64.deb)
-- [amd64 1.3.1 rpm](downloads/uniqush-push-1.3.1-1.x86_64.rpm)
-- [amd64 1.3.1 tar.gz](downloads/uniqush-push_1.3.1_x86_64.tar.gz)
+- [amd64 1.3.1 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.3.1)
+- [amd64 1.3.1 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.3.1)
+- [amd64 1.3.1 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.3.1)
 
 [uniqush-push 1.3.0 release note](release-notes/rn-uniqush-push-1-3-0.html)
 
-- [amd64 1.3.0 deb](downloads/uniqush-push_1.3.0_amd64.deb)
-- [amd64 1.3.0 rpm](downloads/uniqush-push-1.3.0-1.x86_64.rpm)
-- [amd64 1.3.0 tar.gz](downloads/uniqush-push_1.3.0_x86_64.tar.gz)
+- [amd64 1.3.0 deb](https://github.com/uniqush/uniqush-push/releases/tag/1.3.0)
+- [amd64 1.3.0 rpm](https://github.com/uniqush/uniqush-push/releases/tag/1.3.0)
+- [amd64 1.3.0 tar.gz](https://github.com/uniqush/uniqush-push/releases/tag/1.3.0)


### PR DESCRIPTION
Not 100% sure if linking to releases binary URLs directly is
recommended, so this links to the release description.

I also created legacy releases from 1.3.0 -1.3.2 with the release deb/rpm/tar.gz files that I had a local copy of (e.g. https://github.com/uniqush/uniqush-push/releases/tag/1.3.0)